### PR TITLE
Add vertex cover approximation

### DIFF
--- a/client/src/Components/SideBar.tsx
+++ b/client/src/Components/SideBar.tsx
@@ -216,6 +216,15 @@ export default function (props: {
                             >Brute force search with kernelization</Button>
                         </ButtonGroup>
                         <p style={{marginTop: "10px"}}>{vertexCoverKernelizedTime > 0 ? "Vertex cover took: " + vertexCoverKernelizedTime + " seconds" : "Brute force with kernelization has not been run yet."}</p>
+                        <H6 style={{color: "#137CBD"}}>Approximation vertex cover</H6>
+                        <ButtonGroup>
+                            <Button
+                                onClick={() => {
+                                    getVertexCover('/vertex-cover-approximation', "Approximation vertex cover")
+                                }}
+                            >Approximation vertex cover</Button>
+                        </ButtonGroup>
+                        <p style={{marginTop: "10px"}}>{vertexCoverTime > 0 ? "Approximation of vertex cover took: " + vertexCoverTime + " seconds" : "Approximation has not been run yet."}</p>
                     </Collapse>
                 </div>
                 <div style={{

--- a/server/graph.py
+++ b/server/graph.py
@@ -352,7 +352,7 @@ class Graph:
         # greater than k, each remaining vertex can only cover at most k edges and a set of k vertices could only
         # cover at most k^2 edges. In this case, the instance may be replaced by an instance with two vertices,
         # one edge, and k = 0, which also has no solution.
-        if len(self.edges()) > k ** 2 and k is not -1:
+        if len(self.edges()) > k ** 2 and k != -1:
             return {}, None
 
         return self.graph, covered

--- a/server/graph.py
+++ b/server/graph.py
@@ -356,3 +356,20 @@ class Graph:
             return {}, None
 
         return self.graph, covered
+
+    def approximation(self):
+        # Initialize the empty cover.
+        cover = []
+        edges = self.edges()
+
+        # Consider a set of all edges in a graph.
+        while edges:
+            # Pick an arbitrary edges (u, v) from that set and add both u and v to the cover.
+            u, v = random.choice(edges)
+            cover.append(u)
+            cover.append(v)
+            # Remove all edges from that set that are incident on u or v.
+            edges = [e for e in edges if e[0] is not u and e[0] is not v and e[1] is not u and e[1] is not v]
+
+        # Return the result
+        return cover

--- a/server/main.py
+++ b/server/main.py
@@ -78,6 +78,12 @@ def vertex_cover(c: CoverItem):
     return reduction_graph.vertex_cover_brute(c.k, c.depth, best=reduction[1])[0]
 
 
+@app.post("/vertex-cover-approximation")
+def vertex_cover(c: CoverItem):
+    graph = Graph(c.graph)
+    return graph.approximation()
+
+
 @app.put("/increase-pendants")
 def increase_pendants(g: UpdateItem):
     graph = Graph(g.graph)


### PR DESCRIPTION
The algorithm in pseudocode:
```
C = ∅
while E ≠ ∅
    pick any {u, v} ∈ E
    C = C ∪ {u, v}
    delete all edges incident to either u or v

return C
```